### PR TITLE
解决了vue页面的样式分离

### DIFF
--- a/src/assets/css/base.less
+++ b/src/assets/css/base.less
@@ -98,7 +98,7 @@
 }
 
 /* 清除浮动，貌似最完美的解决方案 */
-.clearFix {
+.clearFix (){
     &:after {
         clear: both;
         content: '.';
@@ -152,18 +152,18 @@
 }
 
 /* 整体居中 */
-.center {
+.center (){
     margin-left: auto;
     margin-right: auto;
 }
 
-// .bodyCenter {
-// @include rectangle(@maxWidth, auto);
-// @include center();
-// }
+.bodyCenter (@maxWidth){
+  @include rectangle(@maxWidth, auto);
+  @include center();
+}
 
 /* 垂直居中 */
-.centerMiddle {
+.centerMiddle () {
     display: table-cell;
     vertical-align: middle;
 }

--- a/src/assets/css/base.less
+++ b/src/assets/css/base.less
@@ -118,32 +118,32 @@
 }
 
 /* 使用纯CSS现实三角形，兼容所有浏览器；使用了三个参数，第一个是"方向"，第二个是"大小"，第三个是"颜色"，省得每次都写一大堆代码，非常方便啦； */
-.arrow(@direction, @size, @color) {
-    width: 0;
-    height: 0;
-    line-height: 0;
-    font-size: 0;
-    overflow: hidden;
-    border-width: @size;
-    cursor: pointer;
-@if @direction = = top {
-    border-style: dashed dashed solid dashed;
-    border-color: transparent transparent @color transparent;
-    border-top: none;
-} @else if @direction = = bottom {
-    border-style: solid dashed dashed dashed;
-    border-color: @color transparent transparent transparent;
-    border-bottom: none;
-} @else if @direction = = right {
-    border-style: dashed dashed dashed solid;
-    border-color: transparent transparent transparent @color;
-    border-right: none;
-} @else if @direction = = left {
-    border-style: dashed solid dashed dashed;
-    border-color: transparent @color transparent transparent;
-    border-left: none;
-}
-}
+// .arrow(@direction, @size, @color) {
+//     width: 0;
+//     height: 0;
+//     line-height: 0;
+//     font-size: 0;
+//     overflow: hidden;
+//     border-width: @size;
+//     cursor: pointer;
+// @if @direction = = top {
+//     border-style: dashed dashed solid dashed;
+//     border-color: transparent transparent @color transparent;
+//     border-top: none;
+// } @else if @direction = = bottom {
+//     border-style: solid dashed dashed dashed;
+//     border-color: @color transparent transparent transparent;
+//     border-bottom: none;
+// } @else if @direction = = right {
+//     border-style: dashed dashed dashed solid;
+//     border-color: transparent transparent transparent @color;
+//     border-right: none;
+// } @else if @direction = = left {
+//     border-style: dashed solid dashed dashed;
+//     border-color: transparent @color transparent transparent;
+//     border-left: none;
+// }
+// }
 
 /* 一个区块 */
 .rectangle(@width, @height) {
@@ -157,10 +157,10 @@
     margin-right: auto;
 }
 
-.bodyCenter (@maxWidth){
-  @include rectangle(@maxWidth, auto);
-  @include center();
-}
+// .bodyCenter (@maxWidth){
+//   @include rectangle(@maxWidth, auto);
+//   @include center();
+// }
 
 /* 垂直居中 */
 .centerMiddle () {

--- a/src/views/index/app.js
+++ b/src/views/index/app.js
@@ -5,16 +5,16 @@ import 'muse-ui/lib/styles/base.less';
 import 'assets/css/global.less';
 import 'assets/fonts/iconfont.css';
 
-if (process.env === 'production') {
-  window.apiready = function () {
-    new Vue({
-      el: '#app',
-      render: h => h(App)
-    });
-  };
-} else {
-  new Vue({
-    el: '#app',
-    render: h => h(App)
-  });
-}
+// if (process.env === 'production') {
+//   window.apiready = function () {
+//     new Vue({
+//       el: '#app',
+//       render: h => h(App)
+//     });
+//   };
+// } else {
+new Vue({
+  el: '#app',
+  render: h => h(App)
+});
+// }

--- a/src/views/index/app.js
+++ b/src/views/index/app.js
@@ -5,16 +5,16 @@ import 'muse-ui/lib/styles/base.less';
 import 'assets/css/global.less';
 import 'assets/fonts/iconfont.css';
 
-// if (process.env === 'production') {
-//   window.apiready = function () {
-//     new Vue({
-//       el: '#app',
-//       render: h => h(App)
-//     });
-//   };
-// } else {
-new Vue({
-  el: '#app',
-  render: h => h(App)
-});
-// }
+if (process.env === 'production') {
+  window.apiready = function () {
+    new Vue({
+      el: '#app',
+      render: h => h(App)
+    });
+  };
+} else {
+  new Vue({
+    el: '#app',
+    render: h => h(App)
+  });
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -123,10 +123,7 @@ let config = {
     new CommonsChunkPlugin({
       name: 'vendor',
       minChunks: module => {
-        if (/css&/.test(module.resource)) {
-          console.log(module.resource);
-        }
-        return module.resource && /node_modules/.test(module.resource);
+        return module.resource && (/node_modules/.test(module.resource) || /assets/.test(module.resource));
       }
     }),
     new CommonsChunkPlugin({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -126,14 +126,15 @@ let config = {
         return module.resource && (/node_modules/.test(module.resource) || /assets/.test(module.resource));
       }
     }),
-    new CommonsChunkPlugin({
-      name: 'client',
-      async: 'chunk-vendor',
-      children: true,
-      minChunks: (module, count) => {
-        return count >= 3;
-      }
-    }),
+    // 应该是异步加载的资源的chunk
+    // new CommonsChunkPlugin({
+    //   name: 'client',
+    //   async: 'chunk-vendor',
+    //   children: true,
+    //   minChunks: (module, count) => {
+    //     return count >= 3;
+    //   }
+    // }),
     new CommonsChunkPlugin({
       name: 'runtime',
       minChunks: Infinity

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,7 +52,7 @@ let config = {
               {
                 loader: 'css-loader',
                 options: {
-                  minimize: true
+                  minimize: process.env.NODE_ENV === 'production'
                 }
               },
               'autoprefixer-loader',
@@ -73,7 +73,7 @@ let config = {
           use: {
             loader: 'css-loader',
             options: {
-              minimize: true
+              minimize: process.env.NODE_ENV === 'production'
             }
           }
         })
@@ -94,7 +94,7 @@ let config = {
             {
               loader: 'css-loader',
               options: {
-                minimize: true
+                minimize: process.env.NODE_ENV === 'production'
               }
             },
             'autoprefixer-loader',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,83 +37,103 @@ let config = {
     // { MYAPP: "window.APP" }
   ],
   module: {
-    rules: [{
-      test: /\.vue$/,
-      use: 'vue-loader'
-    },
-    {
-      test: /\.js$/,
-      use: 'babel-loader',
-      exclude: /node_modules/
-    },
-    {
-      test: /\.css$/,
-      use: ExtractTextPlugin.extract({
-        fallback: 'style-loader',
-        use: {
-          loader: 'css-loader',
-          options: {
-            minimize: true
-          }
-        }
-      })
-    },
-    // {
-    //   test: /\.less$/,
-    //   use: [
-    //     'style-loader',
-    //     { loader: 'css-loader', options: { importLoaders: 1 } },
-    //     'less-loader'
-    //   ]
-    // },
-    {
-      test: /\.less$/,
-      use: ExtractTextPlugin.extract({
-        fallback: 'style-loader',
-        use: [
-          {
+    rules: [
+      // {
+      //   test: /\.vue$/,
+      //   use: 'vue-loader'
+      // },
+      {
+        test: /\.vue$/,
+        loader: 'vue-loader',
+        options: {loaders: {
+          less: ExtractTextPlugin.extract({
+            fallback: 'style-loader',
+            use: [
+              {
+                loader: 'css-loader',
+                options: {
+                  minimize: true
+                }
+              },
+              'autoprefixer-loader',
+              'less-loader'
+            ]
+          })
+        }}
+      },
+      {
+        test: /\.js$/,
+        use: 'babel-loader',
+        exclude: /node_modules/
+      },
+      {
+        test: /\.css$/,
+        use: ExtractTextPlugin.extract({
+          fallback: 'style-loader',
+          use: {
             loader: 'css-loader',
             options: {
               minimize: true
             }
-          },
-          'autoprefixer-loader',
-          'less-loader'
-        ]
-      })
-    },
-    {
-      test: /\.html$/,
-      use: [{
-        loader: 'html-loader',
-        options: {
-          root: resolve(__dirname, 'src'),
-          attrs: ['img:src', 'link:href']
-        }
-      }]
-    },
-    {
-      test: /\.(png|jpe?g|gif|svg|svgz)(\?.+)?$/,
-      exclude: /iconfont\.svg/,
-      use: [{
-        loader: 'url-loader',
-        options: {
-          limit: 10000,
-          name: 'assets/img/[name].[ext]'
-        }
-      }]
-    },
-    {
-      test: /\.(eot|ttf|woff|woff2|svg|svgz)(\?.+)?$/,
-      include: /assets/,
-      use: [{
-        loader: 'url-loader',
-        options: {
-          limit: 10000,
-          name: 'assets/fonts/[name].[ext]'
-        }
-      }]
-    }
+          }
+        })
+      },
+      // {
+      //   test: /\.less$/,
+      //   use: [
+      //     'style-loader',
+      //     { loader: 'css-loader', options: { importLoaders: 1 } },
+      //     'less-loader'
+      //   ]
+      // },
+      {
+        test: /\.less$/,
+        use: ExtractTextPlugin.extract({
+          fallback: 'style-loader',
+          use: [
+            {
+              loader: 'css-loader',
+              options: {
+                minimize: true
+              }
+            },
+            'autoprefixer-loader',
+            'less-loader'
+          ]
+        })
+      },
+      {
+        test: /\.html$/,
+        use: [{
+          loader: 'html-loader',
+          options: {
+            root: resolve(__dirname, 'src'),
+            attrs: ['img:src', 'link:href']
+          }
+        }]
+      },
+      {
+        test: /\.(png|jpe?g|gif|svg|svgz)(\?.+)?$/,
+        exclude: /iconfont\.svg/,
+        use: [{
+          loader: 'url-loader',
+          options: {
+            limit: 10000,
+            name: 'assets/img/[name].[ext]'
+          }
+        }]
+      },
+      {
+        test: /\.(eot|ttf|woff|woff2|svg|svgz)(\?.+)?$/,
+        include: /assets/,
+        use: [{
+          loader: 'url-loader',
+          options: {
+            limit: 10000,
+            name: 'assets/fonts/[name].[ext]'
+          }
+        }]
+      }
     ]
   },
   plugins: [
@@ -184,6 +204,7 @@ pages.forEach(function (pathname) {
     conf.hash = true;
   }
   config.plugins.push(new HtmlWebpackPlugin(conf));
+  // config.plugins.push(new ExtractTextPlugin(fileBasename + '.css'));
 });
 
 // function getCommonChunks (chunks) {


### PR DESCRIPTION
assets下的js,less,css都打包到对应的vendor
删除了一个无用的异步加载的资源的chunk
通过设置vue-loader的less属性把style里面的样式生成页面独立的css
非生产环境下css不压缩为一行
修改一些无用的less函数